### PR TITLE
Refer to the right FormControl

### DIFF
--- a/projects/lux/src/lib/input/input.component.ts
+++ b/projects/lux/src/lib/input/input.component.ts
@@ -126,7 +126,7 @@ export class InputComponent implements OnInit {
     if (this.isGeolocation()) {
       this.value = {
         type: 'Point',
-        coordinates: [this.formControl.value, +newValue]
+        coordinates: [this.formControl2.value, +newValue]
       };
     } else {
       this.value = newValue;


### PR DESCRIPTION
Change formControl to formControl2 to correctly refer to latitude instead of longitude and keep latitude value from being copied
Fixes #78 