### PR TITLE
Implement ControlValueAccessor + Validator

### DIFF
--- a/projects/lux/src/lib/input/input.component.html
+++ b/projects/lux/src/lib/input/input.component.html
@@ -1,43 +1,43 @@
 <div *ngIf="currency && currency === 'USD'" class="prefix">
-    <span>$</span>
+  <span>$</span>
 </div>
-<input #i1 placement="top"
-    [id]="inputId"
-    [attr.aria-label]="ariaLabel"
-    [type]="domain"
-    [attr.disabled]="disabled || null"
-    [attr.readonly]="readonly || null"
-    [attr.min]="min || null"
-    [attr.max]="max || null"
-    [attr.step]="step || null"
-    [placeholder]="placeholder"
-    [formControl]="formControl"
-    [ngClass]="className"
-    (keyup)="onKeyUp(i1.value)"
-    (change)="onChange(i1.value)"
-    (keypress)="onKeyPress($event)"
-    >
+<input
+  #i1
+  placement="top"
+  [id]="inputId"
+  [attr.aria-label]="ariaLabel"
+  [type]="domain"
+  [attr.disabled]="disabled || null"
+  [attr.readonly]="readonly || null"
+  [attr.min]="min || null"
+  [attr.max]="max || null"
+  [attr.step]="step || null"
+  [placeholder]="placeholder"
+  [ngClass]="className"
+  (focus)="markAsTouched()"
+  (keyup)="onKeyUp(i1.value)"
+  (change)="onChangeValue(i1.value)"
+  (keypress)="onKeyPress($event)"
+/>
 <div *ngIf="currency && currency === 'EUR'" class="postfix">
-    <span>€</span>
+  <span>€</span>
 </div>
 <div *ngIf="isPercentage()" class="postfix">
-    <span>%</span>
+  <span>%</span>
 </div>
 <div *ngIf="isPermillage()" class="postfix">
-    <span>‰</span>
+  <span>‰</span>
 </div>
 
-<div *ngIf="formControl.invalid && (formControl.dirty || formControl.touched)" class="alert">
-    <div *ngIf="formControl.errors.required">
-        Value is required
-    </div>
-    <div *ngIf="formControl.errors.email">
-        Format should be example@example.com
-    </div>
-    <div *ngIf="formControl.errors.min">
-        Min value is {{min}}
-    </div>
-    <div *ngIf="formControl.errors.max">
-        Max value is {{max}}
-    </div>
+<div *ngIf="inlineErrors && lastErrors && (dirty || touched)" class="alert">
+  <div *ngIf="lastErrors.required">
+    {{ userErrors[this.lang].required }}
+  </div>
+  <div *ngIf="lastErrors.email">{{ userErrors[this.lang].email }}</div>
+  <div *ngIf="lastErrors.min">
+    {{ userErrors[this.lang].min.replace('$min', lastErrors.min.min) }}
+  </div>
+  <div *ngIf="lastErrors.max">
+    {{ userErrors[this.lang].max.replace('$max', lastErrors.max.max) }}
+  </div>
 </div>

--- a/projects/lux/src/lib/input/input.component.spec.ts
+++ b/projects/lux/src/lib/input/input.component.spec.ts
@@ -32,18 +32,6 @@ describe('InputComponent', () => {
       expect(valueEmitterSpy).toHaveBeenCalled();
     });
 
-    it('Updated Validators when input is required', () => {
-      const updateSpy = spyOn(component, 'updateValidators');
-      component.required = true;
-      expect(updateSpy).toHaveBeenCalled();
-    });
-
-    it('Updated Validators when type is set to email', () => {
-      const updateSpy = spyOn(component, 'updateValidators');
-      component.type = 'email';
-      expect(updateSpy).toHaveBeenCalled();
-    });
-
     it('When input type is number, domain should be number', () => {
       component.type = 'number';
       expect(component.domain).toEqual('number');
@@ -84,12 +72,6 @@ describe('InputComponent', () => {
       expect(component.domain).toEqual('number');
     });
 
-    it('When input type is percentage, the update validators should be called', () => {
-      const updateValidatorsSpy = spyOn(component, 'updateValidators');
-      component.type = 'percentage';
-      expect(updateValidatorsSpy).toHaveBeenCalled();
-    });
-
     it('When input type is permillage, the min should be 0 and the max should be 1000', () => {
       component.type = 'permillage';
       expect(component.max).toEqual(1000);
@@ -104,12 +86,6 @@ describe('InputComponent', () => {
     it('When input type is permillage, the domain should be number', () => {
       component.type = 'permillage';
       expect(component.domain).toEqual('number');
-    });
-
-    it('When input type is permillage, the update validators should be called', () => {
-      const updateValidatorsSpy = spyOn(component, 'updateValidators');
-      component.type = 'permillage';
-      expect(updateValidatorsSpy).toHaveBeenCalled();
     });
   });
 

--- a/projects/lux/src/lib/input/input.component.ts
+++ b/projects/lux/src/lib/input/input.component.ts
@@ -121,7 +121,6 @@ export class InputComponent implements OnInit, ControlValueAccessor, Validator {
     }
     this._value = v;
     this.onChange(v);
-    // this.formControl.setValue(v);
     this.valueChange.emit(v);
   }
   get value(): any {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,7 +1,7 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 import { LuxModule } from 'projects/lux/src/public-api';
 import { AutoCompleteSampleComponent } from './autocomplete-sample/autocomplete-sample.component';
@@ -64,6 +64,7 @@ const appRoutes: Routes = [
   imports: [
     CoreModule,
     FormsModule,
+    ReactiveFormsModule,
     LuxModule,
     BrowserModule,
     RouterModule.forRoot(appRoutes)

--- a/src/app/input-sample/input-sample.component.html
+++ b/src/app/input-sample/input-sample.component.html
@@ -3,185 +3,297 @@
 <h2>Attributes</h2>
 
 <div>
-
-    <h3>value</h3>
-    <pre class="language-html" rel="html">
+  <h3>value</h3>
+  <pre class="language-html" rel="html">
         <code class="language-html">
         &lt;lux-input aria-label="Value example" [(value)]="value"&gt;&lt;/lux-input&gt;</code>
     </pre>
-    <div class="sample">
-        <lux-input aria-label="Value example" [(value)]="value1"></lux-input> <span>Bind value: {{ value1 }}</span>
-    </div>
+  <div class="sample">
+    <lux-input aria-label="Value example" [(value)]="value1"></lux-input>
+    <span>Bind value: {{ value1 }}</span>
+  </div>
 
-    <h3>inputId</h3>
-    <pre class="language-html" rel="html">
+  <h3>inputId</h3>
+  <pre class="language-html" rel="html">
         <code class="language-html">
         &lt;label for="someid"&gt;inputId example&lt;/label&gt;
         &lt;lux-input inputId="someid" [(value)]="name"&gt;&lt;/lux-input&gt;</code>
     </pre>
-    <div class="sample">
-        <label for="someid">inputId example:</label>
-        <lux-input inputId="someid" [(value)]="name"></lux-input> <span>Bind value: {{ name }}</span>
-    </div>
+  <div class="sample">
+    <label for="someid">inputId example:</label>
+    <lux-input inputId="someid" [(value)]="name"></lux-input>
+    <span>Bind value: {{ name }}</span>
+  </div>
 
-    <h3>Disabled</h3>
-    <pre class="language-html" rel="html">
+  <h3>Disabled</h3>
+  <pre class="language-html" rel="html">
         <code class="language-html">
     &lt;lux-input aria-label="Disabled example" [(value)]="value" <span class="text-underlined">disabled</span>&gt;&lt;/lux-input&gt;</code>
     </pre>
-    <div class="sample">
-        <lux-input aria-label="Disabled example" [(value)]="value" disabled></lux-input>
-    </div>
+  <div class="sample">
+    <lux-input
+      aria-label="Disabled example"
+      [(value)]="value"
+      disabled
+    ></lux-input>
+  </div>
 
-    <h3>Readonly</h3>
-    <pre class="language-html" rel="html">
+  <h3>Readonly</h3>
+  <pre class="language-html" rel="html">
         <code class="language-html">
     &lt;lux-input aria-label="Readonly example" [(value)]="value" <span class="text-underlined">[readonly]="true"</span>&gt;&lt;/lux-input&gt;</code>
     </pre>
-    <div class="sample">
-        <lux-input aria-label="Readonly example" [(value)]="value" [readonly]="true"></lux-input>
-    </div>
+  <div class="sample">
+    <lux-input
+      aria-label="Readonly example"
+      [(value)]="value"
+      [readonly]="true"
+    ></lux-input>
+  </div>
 
-    <h3>Placeholder</h3>
-    <pre class="language-html" rel="html">
+  <h3>Placeholder</h3>
+  <pre class="language-html" rel="html">
         <code class="language-html">
     &lt;lux-input aria-label="Placeholder example" <span class="text-underlined">[placeholder]="placeholder"</span>&gt;&lt;/lux-input&gt;</code>
     </pre>
-    <div class="sample">
-        <lux-input aria-label="Placeholder example" [placeholder]="'Write text...'"></lux-input>
-    </div>
-    <pre class="language-html" rel="html">
+  <div class="sample">
+    <lux-input
+      aria-label="Placeholder example"
+      [placeholder]="'Write text...'"
+    ></lux-input>
+  </div>
+  <pre class="language-html" rel="html">
         <code class="language-html">
     &lt;lux-input aria-label="Placeholder example 2" <span class="text-underlined">placeholder="Write text..."</span>&gt;&lt;/lux-input&gt;</code>
     </pre>
-    <div class="sample">
-        <lux-input aria-label="Placeholder example 2" placeholder="Write text..."></lux-input>
-    </div>
+  <div class="sample">
+    <lux-input
+      aria-label="Placeholder example 2"
+      placeholder="Write text..."
+    ></lux-input>
+  </div>
 
-    <h3>Required</h3>
-    <pre class="language-html" rel="html">
+  <h3>Required</h3>
+  <pre class="language-html" rel="html">
         <code class="language-html">
     &lt;lux-input aria-label="Required example" <span class="text-underlined">required</span>&gt;&lt;/lux-input&gt;</code>
     </pre>
-    <div class="sample">
-        <lux-input aria-label="Required example" required></lux-input>
-    </div>
-
+  <div class="sample">
+    <lux-input aria-label="Required example" required></lux-input>
+  </div>
 </div>
 
 <h2>Types</h2>
 
 <div>
-
-    <h3>Email</h3>
-    <pre class="language-html" rel="html">
+  <h3>Email</h3>
+  <pre class="language-html" rel="html">
         <code class="language-html">
     &lt;lux-input placeholder="Write text..." <span class="text-underlined">type="email"</span> &gt;&lt;/lux-input&gt;</code>
     </pre>
-    <div class="sample">
-      <label for="email">Email: </label>
-      <lux-input inputId="email" placeholder="Write text..." type="email" [(value)]="valueEmail"></lux-input>
-      Bind value: {{ valueEmail }}
-    </div>
+  <div class="sample">
+    <label for="email">Email: </label>
+    <lux-input
+      inputId="email"
+      placeholder="Write text..."
+      type="email"
+      [(value)]="valueEmail"
+    ></lux-input>
+    Bind value: {{ valueEmail }}
+  </div>
 
-    <h3>Date</h3>
-    <pre class="language-html" rel="html">
+  <h3>Date</h3>
+  <pre class="language-html" rel="html">
         <code class="language-html">
     &lt;lux-input <span class="text-underlined">type="date"</span>&gt;&lt;/lux-input&gt;</code>
     </pre>
-    <div class="sample">
-      <label for="date">Date: </label>
-      <lux-input inputId="date" type="date" [(value)]="valueDate"></lux-input>
-      Bind value: {{ valueDate }}
-    </div>
+  <div class="sample">
+    <label for="date">Date: </label>
+    <lux-input inputId="date" type="date" [(value)]="valueDate"></lux-input>
+    Bind value: {{ valueDate }}
+  </div>
 
-    <h3>Time</h3>
-    <pre class="language-html" rel="html">
+  <h3>Time</h3>
+  <pre class="language-html" rel="html">
         <code class="language-html">
     &lt;lux-input <span class="text-underlined">type="time"</span>&gt;&lt;/lux-input&gt;</code>
     </pre>
-    <div class="sample">
-      <label for="time">Time: </label>
-      <lux-input inputId="time" type="time" [(value)]="valueTime"></lux-input>
-      Bind value: {{ valueTime }}
-    </div>
+  <div class="sample">
+    <label for="time">Time: </label>
+    <lux-input inputId="time" type="time" [(value)]="valueTime"></lux-input>
+    Bind value: {{ valueTime }}
+  </div>
 
-    <h3>Password</h3>
-    <pre class="language-html" rel="html">
+  <h3>Password</h3>
+  <pre class="language-html" rel="html">
         <code class="language-html">
     &lt;lux-input <span class="text-underlined">type="password"</span>&gt;&lt;/lux-input&gt;</code>
     </pre>
-    <div class="sample">
-        <label for="password">Password: </label>
-        <lux-input inputId="password" type="password" [(value)]="valuePassword"></lux-input>
-        Bind value: {{ valuePassword }}
-    </div>
+  <div class="sample">
+    <label for="password">Password: </label>
+    <lux-input
+      inputId="password"
+      type="password"
+      [(value)]="valuePassword"
+    ></lux-input>
+    Bind value: {{ valuePassword }}
+  </div>
 
-    <h3>Number</h3>
-    <pre class="language-html" rel="html">
+  <h3>Number</h3>
+  <pre class="language-html" rel="html">
             <code class="language-html">
     &lt;lux-input <span class="text-underlined">type="number"</span>&gt;&lt;/lux-input&gt;</code>
     </pre>
-    <div class="sample">
-      <label for="numeric">Numeric value: </label>
-      <lux-input inputId="numeric" type="number" [(value)]="valueNumber"></lux-input>
-      Bind value: {{ valueNumber }}
-    </div>
+  <div class="sample">
+    <label for="numeric">Numeric value: </label>
+    <lux-input
+      inputId="numeric"
+      type="number"
+      [(value)]="valueNumber"
+    ></lux-input>
+    Bind value: {{ valueNumber }}
+  </div>
 
-    <h3>Currency</h3>
-    <pre class="language-html" rel="html">
+  <h3>Currency</h3>
+  <pre class="language-html" rel="html">
         <code class="language-html">
     &lt;lux-input <span class="text-underlined">type="currency" currency="USD"</span>&gt;&lt;/lux-input&gt;</code>
     </pre>
-    <div class="sample">
-      <label for="currency1">Currency value: </label>
-      <lux-input inputId="currency1" type="currency" currency="USD" [(value)]="valueCurrencyUsd"></lux-input>
-      Bind value: {{ valueCurrencyUsd }} USD
-    </div>
-    <pre class="language-html" rel="html">
+  <div class="sample">
+    <label for="currency1">Currency value: </label>
+    <lux-input
+      inputId="currency1"
+      type="currency"
+      currency="USD"
+      [(value)]="valueCurrencyUsd"
+    ></lux-input>
+    Bind value: {{ valueCurrencyUsd }} USD
+  </div>
+  <pre class="language-html" rel="html">
         <code class="language-html">
     &lt;lux-input <span class="text-underlined">type="currency" currency="EUR"</span>&gt;&lt;/lux-input&gt;</code>
     </pre>
-    <div class="sample">
-      <label for="currency2">Currency value: </label>
-      <lux-input inputId="currency2" type="currency" currency="EUR" [(value)]="valueCurrencyEur"></lux-input>
-      Bind value: {{ valueCurrencyEur }} EUR
-    </div>
+  <div class="sample">
+    <label for="currency2">Currency value: </label>
+    <lux-input
+      inputId="currency2"
+      type="currency"
+      currency="EUR"
+      [(value)]="valueCurrencyEur"
+    ></lux-input>
+    Bind value: {{ valueCurrencyEur }} EUR
+  </div>
 
-    <h3>Percentage</h3>
-    <pre class="language-html" rel="html">
+  <h3>Percentage</h3>
+  <pre class="language-html" rel="html">
       <code class="language-html">
     &lt;lux-input <span class="text-underlined">type="percentage"</span>&gt;&lt;/lux-input&gt;</code>
     </pre>
-    <div class="sample">
-      <label for="percentage">Percentage value: </label>
-      <lux-input inputId="percentage" type="percentage"  [(value)]="valuePercentage"></lux-input>
-      Bind value: {{ valuePercentage }}
-    </div>
+  <div class="sample">
+    <label for="percentage">Percentage value: </label>
+    <lux-input
+      inputId="percentage"
+      type="percentage"
+      [(value)]="valuePercentage"
+    ></lux-input>
+    Bind value: {{ valuePercentage }}
+  </div>
 
-    <h3>Permillage</h3>
-    <pre class="language-html" rel="html">
+  <h3>Permillage</h3>
+  <pre class="language-html" rel="html">
             <code class="language-html">
     &lt;lux-input <span class="text-underlined">type="permillage"</span>&gt;&lt;/lux-input&gt;</code>
     </pre>
-    <div class="sample">
-      <label for="permillage">Permillage value: </label>
-      <lux-input inputId="permillage" type="permillage"  [(value)]="valuePermillage"></lux-input>
-      Bind value: {{ valuePermillage }}
-    </div>
+  <div class="sample">
+    <label for="permillage">Permillage value: </label>
+    <lux-input
+      inputId="permillage"
+      type="permillage"
+      [(value)]="valuePermillage"
+    ></lux-input>
+    Bind value: {{ valuePermillage }}
+  </div>
+</div>
+
+<h2>Sandbox. Form Simulator</h2>
+<div>
+  <div>
+    <label for="t1">Change type:</label>
+    <select name="t1" [(ngModel)]="f1.type">
+      <option value="string">string</option>
+      <option value="email">email</option>
+      <option value="date">date</option>
+      <option value="time">time</option>
+      <option value="currency">currency</option>
+      <option value="percent">percent</option>
+      <option value="permillage">permillage</option>
+      <option value="number">number</option>
+    </select>
+  </div>
+  <div>
+    <label for="t1">
+      <input
+        type="checkbox"
+        name="t1"
+        [(ngModel)]="f1.required"
+      />Required</label
+    >
+  </div>
+  <div>
+    <label for="inlineErrors">
+      <input
+        type="checkbox"
+        name="inlineErrors"
+        [(ngModel)]="f1.inlineErrors"
+      />Show inline errors</label
+    >
+  </div>
+  <hr />
+
+  <h3>Form</h3>
+  <form #form="ngForm">
+    <label for="field1">Field 1:</label>
+    <lux-input
+      name="field1"
+      inputId="field1"
+      [type]="f1.type"
+      [required]="f1.required"
+      [inlineErrors]="f1.inlineErrors"
+      [(ngModel)]="f1.formValues.field1"
+      #f1Val="ngModel"
+    >
+    </lux-input>
+    <div *ngIf="!f1Val.valid">Debug: {{ f1Val.errors | json }}</div>
+    <button [disabled]="!form.valid">Fake sumbit</button>
+  </form>
 </div>
 
 <h2>Documentation</h2>
 <h3>Properties</h3>
 <ul class="properties">
-  <li><span class="inline">inputId</span> id for the input. If left blank, it is autogenerated.</li>
-  <li><span class="inline">aria-label</span> Custom aria label forwarded to the input.</li>
-  <li><span class="inline">step</span> For numeric types: the discrete increment/decrement when using the arrows.</li>
+  <li>
+    <span class="inline">inputId</span> id for the input. If left blank, it is
+    autogenerated.
+  </li>
+  <li>
+    <span class="inline">aria-label</span> Custom aria label forwarded to the
+    input.
+  </li>
+  <li>
+    <span class="inline">step</span> For numeric types: the discrete
+    increment/decrement when using the arrows.
+  </li>
   <li><span class="inline">min</span> For numeric types: maximum value.</li>
   <li><span class="inline">max</span> For numeric types: minimum value.</li>
 </ul>
 <h3>Events</h3>
 <ul class="properties">
-  <li><span class="inline">valueChange</span>Triggered whenever the value changes. Pass the newValue as payload.</li>
-  <li><span class="inline">keyPress</span>Triggered when a key is pressed. Pass the Keyboard event directly.</li>
+  <li>
+    <span class="inline">valueChange</span>Triggered whenever the value changes.
+    Pass the newValue as payload.
+  </li>
+  <li>
+    <span class="inline">keyPress</span>Triggered when a key is pressed. Pass
+    the Keyboard event directly.
+  </li>
 </ul>

--- a/src/app/input-sample/input-sample.component.ts
+++ b/src/app/input-sample/input-sample.component.ts
@@ -22,6 +22,16 @@ export class InputSampleComponent implements AfterContentInit {
   valuePercentage = 75.24;
   valuePermillage = 923.34;
 
+  f1 = {
+    type: 'email',
+    required: true,
+    inlineErrors: false,
+    value: 'a',
+    formValues: {
+      field1: ''
+    }
+  };
+
   constructor(private prismService: PrismService) {}
 
   ngAfterContentInit(): void {


### PR DESCRIPTION
Implement **ControlValueAccessor** + **Validator**
- Removed **FormControl** (not needed, to be used as consumer, not as producer: ControlValueAccessor takes the lead on this)
- Added custom validators
- Add from sandbox on test/doc page
- Allow to show error inline or not (default to false)
- Wired to from validation via implementing ControlValueAccessor  (see sandbox form for testing)
- Added suppport for en/es error inline messages with language detector via `navigator.language`