### PR TITLE
Improve icons of datetime and geolocation and style

### DIFF
--- a/projects/lux/src/lib/datetime/datetime.component.html
+++ b/projects/lux/src/lib/datetime/datetime.component.html
@@ -16,7 +16,7 @@
 />
 <input
   #timeInput
-  [class]="(disabled || readonly) && localTime ? 'rounded-right' : ''"
+  [class]="(disabled || readonly || !isClearable()) && localTime ? 'rounded-right' : ''"
   [ngClass]="className"
   type="time"
   [id]="inputId + '$time'"
@@ -35,7 +35,7 @@
   *ngIf="!localTime"
 >
   <div
-    [class]="disabled || readonly ? 'rounded-right postfix symbol' : 'postfix symbol'"
+    [class]="disabled || readonly || !isClearable() ? 'rounded-right postfix symbol' : 'postfix symbol'"
     [ngClass]="className"
   >
     <span>{{ localTime ? '' : 'UTC' }}</span>
@@ -43,7 +43,7 @@
 </ng-container>
 <button
   #clearButton
-  *ngIf="!(disabled || readonly)"
+  *ngIf="!disabled && !readonly && isClearable()"
   type="button"
   class="rounded-right postfix bordered icon-clear"
   [id]="inputId + '$clear'"

--- a/projects/lux/src/lib/datetime/datetime.component.ts
+++ b/projects/lux/src/lib/datetime/datetime.component.ts
@@ -194,6 +194,9 @@ export class DatetimeComponent
     this.setTimeInControl(null);
     this.value = null;
   }
+  isClearable(): boolean {
+    return hasValue(this.value);
+  }
 
   // Validator interface
   registerOnValidatorChange(): void {}

--- a/projects/lux/src/lib/geolocation/geolocation.component.html
+++ b/projects/lux/src/lib/geolocation/geolocation.component.html
@@ -28,7 +28,7 @@
   (blur)="onLostFocus()"
 />
 <div
-  class="infix symbol clickable"
+  class="infix symbol monospace clickable"
   [ngClass]="className"
   (click)="openModalMap(modalMap)">
   <span *ngIf="isValidNumber(latitudeValue) && latitudeValue >= 0">{{
@@ -69,7 +69,7 @@
   (blur)="onLostFocus()"
 />
 <div
-  class="infix symbol clickable"
+  class="infix symbol monospace clickable"
   [ngClass]="className"
   (click)="openModalMap(modalMap)"
 >

--- a/projects/lux/src/lib/geolocation/geolocation.component.html
+++ b/projects/lux/src/lib/geolocation/geolocation.component.html
@@ -83,7 +83,7 @@
 </div>
 <div
   [class]="
-    disabled || readonly || !(isValidNumber(latitudeValue) || isValidNumber(longitudeValue))
+    disabled || readonly || !isClearable()
       ? 'clickable rounded-right postfix symbol'
       : 'clickable postfix symbol'
   "
@@ -94,7 +94,7 @@
 </div>
 <button
   #clearButton
-  *ngIf="!disabled && !readonly && (isValidNumber(latitudeValue) || isValidNumber(longitudeValue))"
+  *ngIf="!disabled && !readonly && isClearable()"
   class="rounded-right postfix bordered icon icon-clear"
   [id]="inputId + '$clear'"
   type="button"

--- a/projects/lux/src/lib/geolocation/geolocation.component.html
+++ b/projects/lux/src/lib/geolocation/geolocation.component.html
@@ -142,7 +142,7 @@
 
 <ng-template #modalMap let-modal>
   <div class="lux-modal-header">
-    <h4 class="modal-title" id="modal-basic-title">{{ mapTitle }}</h4>
+    <h4 class="modal-title default-font" id="modal-basic-title">{{ mapTitle }}</h4>
     <button
       type="button"
       class="close"

--- a/projects/lux/src/lib/geolocation/geolocation.component.html
+++ b/projects/lux/src/lib/geolocation/geolocation.component.html
@@ -37,7 +37,7 @@
   <span *ngIf="isValidNumber(latitudeValue) && latitudeValue < 0">{{
     i18n[lang].cardinalPoints.south
   }}</span>
-  <span *ngIf="!isValidNumber(latitudeValue)" class="icon-globe"></span>
+  <span *ngIf="!isValidNumber(longitudeValue)">-</span>
 </div>
 <input
   #longitude
@@ -69,11 +69,7 @@
   (blur)="onLostFocus()"
 />
 <div
-  [class]="
-    disabled || readonly
-      ? 'clickable rounded-right postfix symbol'
-      : 'clickable postfix symbol'
-  "
+  class="infix symbol clickable"
   [ngClass]="className"
   (click)="openModalMap(modalMap)"
 >
@@ -83,11 +79,22 @@
   <span *ngIf="isValidNumber(longitudeValue) && longitudeValue < 0">{{
     i18n[lang].cardinalPoints.west
   }}</span>
-  <span *ngIf="!isValidNumber(longitudeValue)" class="icon-globe"></span>
+  <span *ngIf="!isValidNumber(longitudeValue)">-</span>
+</div>
+<div
+  [class]="
+    disabled || readonly || !(isValidNumber(latitudeValue) || isValidNumber(longitudeValue))
+      ? 'clickable rounded-right postfix symbol'
+      : 'clickable postfix symbol'
+  "
+  [ngClass]="className"
+  (click)="openModalMap(modalMap)"
+>
+  <span class="icon-globe"></span>
 </div>
 <button
   #clearButton
-  *ngIf="!(disabled || readonly)"
+  *ngIf="!disabled && !readonly && (isValidNumber(latitudeValue) || isValidNumber(longitudeValue))"
   class="rounded-right postfix bordered icon icon-clear"
   [id]="inputId + '$clear'"
   type="button"

--- a/projects/lux/src/lib/geolocation/geolocation.component.html
+++ b/projects/lux/src/lib/geolocation/geolocation.component.html
@@ -37,7 +37,7 @@
   <span *ngIf="isValidNumber(latitudeValue) && latitudeValue < 0">{{
     i18n[lang].cardinalPoints.south
   }}</span>
-  <span *ngIf="!isValidNumber(longitudeValue)">-</span>
+  <span *ngIf="!isValidNumber(latitudeValue)">-</span>
 </div>
 <input
   #longitude

--- a/projects/lux/src/lib/geolocation/geolocation.component.scss
+++ b/projects/lux/src/lib/geolocation/geolocation.component.scss
@@ -70,5 +70,7 @@ $geolocation-map-width: var(--lux-geolocation-map-width, 90vw);
 }
 .map-container {
   height: $geolocation-map-height;
+  max-height: 80%;
   width: $geolocation-map-width;
+  max-width: 100%;
 }

--- a/projects/lux/src/lib/geolocation/geolocation.component.scss
+++ b/projects/lux/src/lib/geolocation/geolocation.component.scss
@@ -70,7 +70,6 @@ $geolocation-map-width: var(--lux-geolocation-map-width, 90vw);
 }
 .map-container {
   height: $geolocation-map-height;
-  max-height: 80%;
   width: $geolocation-map-width;
   max-width: 100%;
 }

--- a/projects/lux/src/lib/geolocation/geolocation.component.ts
+++ b/projects/lux/src/lib/geolocation/geolocation.component.ts
@@ -237,6 +237,11 @@ export class GeolocationComponent implements OnInit {
     this.setLongitudeInControl(null);
     this.value = null;
   }
+  isClearable(): boolean {
+    return (
+      isValidNumber(this.latitudeValue) || isValidNumber(this.longitudeValue)
+    );
+  }
 
   // Validator interface
   registerOnValidatorChange(): void {}

--- a/projects/lux/src/lib/styles/lux.scss
+++ b/projects/lux/src/lib/styles/lux.scss
@@ -8,6 +8,7 @@
 $symbol-font-size: var(--lux-symbol-font-size, 1rem);
 
 // Colors
+$font-color: var(--lux-font-color, black);
 $alert-color: var(--lux-alert-color, white);
 $alert-background: var(--lux-alert-background, #fe2e2e);
 $symbol-color: var(--lux-symbol-color, default); // Formerly #495057
@@ -46,6 +47,10 @@ $icon-dropdown: var(
 
 :focus {
   z-index: 1;
+}
+
+* {
+  color: $font-color;
 }
 
 input,

--- a/projects/lux/src/lib/styles/lux.scss
+++ b/projects/lux/src/lib/styles/lux.scss
@@ -128,3 +128,7 @@ textarea {
 .monospace {
   font-family: monospace;
 }
+
+.default-font {
+  color: $font-color;
+}

--- a/projects/lux/src/lib/styles/lux.scss
+++ b/projects/lux/src/lib/styles/lux.scss
@@ -49,10 +49,6 @@ $icon-dropdown: var(
   z-index: 1;
 }
 
-* {
-  color: $font-color;
-}
-
 input,
 select,
 textarea {

--- a/projects/lux/src/lib/styles/lux.scss
+++ b/projects/lux/src/lib/styles/lux.scss
@@ -123,3 +123,7 @@ textarea {
   display: flex;
   align-items: center;
 }
+
+.monospace {
+  font-family: monospace;
+}


### PR DESCRIPTION
- `<lux-geolocation>`: Give the icon to open the map modal its own box
- `<lux-datetime>`, `<lux-geolocation>`: Make clear icon disappear if there's no value to clear
- `<lux-geolocation>`: Add maximum width and height to map-container