### PR TITLE
Make lux-input components have the same height when relevant

### DIFF
--- a/projects/lux/src/lib/input/input.component.scss
+++ b/projects/lux/src/lib/input/input.component.scss
@@ -11,6 +11,11 @@ $icon-external: var(
   min-height: 1.5rem;
 }
 
+input[type='color'] {
+  min-height: 100%;
+  height: 0;
+}
+
 .readonly {
   border: none;
 

--- a/projects/lux/src/lib/input/input.component.scss
+++ b/projects/lux/src/lib/input/input.component.scss
@@ -33,6 +33,7 @@ $icon-external: var(
   width: 100%;
   height: 100%;
   margin: 0;
+  border: 0;
   padding: 0;
 }
 .minimal-space {


### PR DESCRIPTION
`<lux-input type="color">` elements are taller than they should. This seems to be caused by Chrome's user agent stylesheet, which sets the height of `<input type="color">` elements to `27px` (`1.6875rem`) while the `<lux-input>` elements usually get the height of their `min-height`, which is `1.5rem` (`24px`).

Simplest solution: Set the `min-height` of `<lux-input>` to `1.8rem`.

Current solution used in this PR: Set the `min-height` of `<input type="color">` to `100%` and its `height` to `0`, thus overriding the height given by the user agent stylesheet and using the maximum height allowed by the parent.