### PR TITLE
Focus on input when opening autocomplete list

### DIFF
--- a/projects/lux/src/lib/autocomplete/autocomplete.component.ts
+++ b/projects/lux/src/lib/autocomplete/autocomplete.component.ts
@@ -341,6 +341,7 @@ export class AutocompleteComponent
   }
   toggleCompletion(show: boolean, label: string): void {
     if (show && !this.disabled) {
+      this.i0.nativeElement.focus();
       this.showCompletionList(label);
     } else {
       this.showCompletion = false;


### PR DESCRIPTION
Focus on input when opening autocomplete list
When opening the list via the dropdown button, focus isn't made on the input element of autocomplete, meaning that when clicking away from the dropdown list, the blur event doesn't fire and the dropdown list doesn't close. By doing focus on the input element upon opening the dropdown list, we can unfocus and close the dropdown list regardless of whether we opened it by clicking on the input or on the dropdown button.